### PR TITLE
Add Visitors to Brush ASTs

### DIFF
--- a/parse/exec_test.go
+++ b/parse/exec_test.go
@@ -1,6 +1,8 @@
 package parse_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -152,6 +154,10 @@ func (tv *TestVisitor) AcceptTextNode(tag *brush.TextNode) {
 	// NOP
 }
 
+func (tv *TestVisitor) String() string {
+	return "Here are my ids: " + strings.Join(tv.Ids, ", ")
+}
+
 func Test_Visitors(t *testing.T) {
 	const doc string = `Here's a bunch of tags: {{ foo id="12345" }} {{ foo id="45678" }}`
 
@@ -174,4 +180,21 @@ func Test_Visitors(t *testing.T) {
 			t.Errorf("Visitor Test: Expected %s to equal %s", tv.Ids[i], elem)
 		}
 	}
+}
+
+func ExampleCompositeVisitor() {
+	document := `
+  This is a document with some tags that have ids:
+  {{ foo id="4815162342" }}
+  {{ foo id="8675309" }}
+  `
+	testVisitor := &TestVisitor{make([]string, 0, 2)}
+	cv := brush.NewCompositeVisitor(testVisitor)
+	handlers := brush.NewHandlerMux()
+	ast, _ := brush.New("default", document, handlers.BlockHandlers()).Parse()
+
+	ast.Visit(cv)
+
+	fmt.Println(testVisitor)
+	// Output: Here are my ids: 4815162342, 8675309
 }

--- a/parse/exec_test.go
+++ b/parse/exec_test.go
@@ -135,3 +135,43 @@ func Test_Default_Handlers(t *testing.T) {
 		}
 	}
 }
+
+type TestVisitor struct {
+	Ids []string
+}
+
+func (tv *TestVisitor) AcceptTag(tag *brush.BraaiTagNode) {
+	tv.Ids = append(tv.Ids, tag.Attributes["id"])
+}
+
+func (tv *TestVisitor) AcceptBlockTag(tag *brush.BlockTagNode) {
+	// NOP
+}
+
+func (tv *TestVisitor) AcceptTextNode(tag *brush.TextNode) {
+	// NOP
+}
+
+func Test_Visitors(t *testing.T) {
+	const doc string = `Here's a bunch of tags: {{ foo id="12345" }} {{ foo id="45678" }}`
+
+	expected := []string{
+		"12345",
+		"45678",
+	}
+
+	tv := &TestVisitor{make([]string, 0, 2)}
+	handlers := brush.NewHandlerMux()
+	ast, err := brush.New("default", doc, handlers.BlockHandlers()).Parse()
+
+	if err != nil {
+		t.Errorf("Visitor Test: encountered error: %s", err.Error())
+	}
+
+	ast.Visit(tv)
+	for i, elem := range expected {
+		if tv.Ids[i] != elem {
+			t.Errorf("Visitor Test: Expected %s to equal %s", tv.Ids[i], elem)
+		}
+	}
+}

--- a/parse/lexer_test.go
+++ b/parse/lexer_test.go
@@ -251,18 +251,18 @@ var lexTests = []lexTest{
 		{itemQuotedArgument, 0, "true"},
 		{itemRightMeta, 0, "}}"},
 	}},
-  {"handle colons and dots in modifier names", "{{ product_shelf max:msrp=\"800\" category__slug=\"foo\" }}", []item{
-    {itemText, 0, ""},
-    {itemLeftMeta, 0, "{{"},
-    {itemIdentifier, 0, "product_shelf"},
-    {itemIdentifier, 0, "max:msrp"},
+	{"handle colons and dots in modifier names", "{{ product_shelf max:msrp=\"800\" category__slug=\"foo\" }}", []item{
+		{itemText, 0, ""},
+		{itemLeftMeta, 0, "{{"},
+		{itemIdentifier, 0, "product_shelf"},
+		{itemIdentifier, 0, "max:msrp"},
 		{itemAssign, 0, "="},
 		{itemQuotedArgument, 0, "800"},
-    {itemIdentifier, 0, "category__slug"},
+		{itemIdentifier, 0, "category__slug"},
 		{itemAssign, 0, "="},
 		{itemQuotedArgument, 0, "foo"},
 		{itemRightMeta, 0, "}}"},
-  }},
+	}},
 }
 
 // Lexes the document in the test and returns a slice of items

--- a/parse/visitors.go
+++ b/parse/visitors.go
@@ -1,0 +1,38 @@
+package parse
+
+// A CompositeVisitor takes an arbitrary number of Visitors and invokes their
+// corresponding Accept methods when its Accept methods are invoked. This
+// allows for one traversal of a Brush AST with an arbitrary number of Visitors.
+type CompositeVisitor struct {
+	visitors []Visitor
+}
+
+// Takes a variadic list of Visitors to allow for easy creation of
+// CompositeVisitors.
+func NewCompositeVisitor(visitors ...Visitor) *CompositeVisitor {
+	return &CompositeVisitor{visitors}
+}
+
+// Accepts BraaiTagNodes and dispatches to the corresponding AcceptTag method
+// of the internal list of visitors.
+func (cv *CompositeVisitor) AcceptTag(b *BraaiTagNode) {
+	for _, visitor := range cv.visitors {
+		visitor.AcceptTag(b)
+	}
+}
+
+// Accepts BlockTagNodes and dispatches to the corresponding AcceptBlockTag method
+// of the internal list of visitors.
+func (cv *CompositeVisitor) AcceptBlockTag(b *BlockTagNode) {
+	for _, visitor := range cv.visitors {
+		visitor.AcceptBlockTag(b)
+	}
+}
+
+// Accepts TextNodes and dispatches to the corresponding AcceptTextNode method
+// of the internal list of visitors.
+func (cv *CompositeVisitor) AcceptTextNode(b *TextNode) {
+	for _, visitor := range cv.visitors {
+		visitor.AcceptTextNode(b)
+	}
+}


### PR DESCRIPTION
Certain applications would benefit greatly from being able to use
Visitors to traverse a Brush AST beforehand. This adds a Visitor
interface which requires Accept methods for the three major leaf nodes
of a Brush AST.
